### PR TITLE
Demonstrate using class overrides with styled-components.

### DIFF
--- a/src/components/DateInput/StyledComponentsExample.tsx
+++ b/src/components/DateInput/StyledComponentsExample.tsx
@@ -23,12 +23,15 @@ export const Input = styled(Cleave)`
   background-color: ${props => (props.disabled ? "#F1F1F2" : undefined)};
 `;
 
-export type StyledComponentsExampleProps = DateInputProps;
+export interface StyledComponentsExampleProps extends DateInputProps {
+  readonly classes?: Record<string, string>;
+}
 
 export const StyledComponentsExample: React.FC<StyledComponentsExampleProps> = ({
   value,
   onChangeDate,
   onChangeString,
+  classes = {},
   disabled
 }) => {
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,7 +48,7 @@ export const StyledComponentsExample: React.FC<StyledComponentsExampleProps> = (
 
   return (
     <Root>
-      <Label htmlFor="input">Date Input</Label>
+      <Label htmlFor="input" className={classes.label}>Date Input</Label>
       <Input
         options={cleaveOptions}
         id="input"
@@ -54,6 +57,7 @@ export const StyledComponentsExample: React.FC<StyledComponentsExampleProps> = (
         value={value}
         onChange={onChange}
         disabled={disabled}
+        className={classes.input}
       />
     </Root>
   );

--- a/src/components/ExampleTable/PlaceholderColorRow.tsx
+++ b/src/components/ExampleTable/PlaceholderColorRow.tsx
@@ -5,7 +5,6 @@ import { CssModulesExample } from "../DateInput/CssModulesExample";
 import { JssUseStylesExample } from "../DateInput/JssUseStylesExample";
 import JssWithStylesExample from "../DateInput/JssWithStylesExample";
 import {
-  Input as SCInput,
   StyledComponentsExample
 } from "../DateInput/StyledComponentsExample";
 import {
@@ -33,17 +32,6 @@ const useStyles = createUseStyles({
     }
   }
 });
-
-const SCWrapper = styled.div`
-  ${SCInput} {
-    background-color: black;
-    color: white;
-  }
-
-  ${SCInput}::placeholder {
-    font-weight: bold;
-  }
-`;
 
 const SCOWrapper = styled.div({
   [SCOInput]: {
@@ -89,13 +77,12 @@ export const PlaceholderColorRow = () => {
         />
       </div>
       <div className="example-grid_cell">
-        <SCWrapper>
-          <StyledComponentsExample
-            value={dateString}
-            onChangeDate={setDateObject}
-            onChangeString={setDateString}
-          />
-        </SCWrapper>
+        <StyledComponentsExample
+          value={dateString}
+          onChangeDate={setDateObject}
+          onChangeString={setDateString}
+          classes={classesFromUseStyles}
+        />
       </div>
       <div className="example-grid_cell">
         <SCOWrapper>


### PR DESCRIPTION
The styled-components override system is handy, but from a component
library perspective, it's an implementation detail that you don't need
to expose. If you're using SC internally, you might still provide a
`classes` prop to allow components to override your styles.